### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,14 +11,6 @@ backend/data/*.db
 *.xml
 *.gpx
 
-# Private keys and credentials
-*.pem
-*.key
-*.p12
-*.pfx
-credentials.json
-service-account*.json
-
 # OS
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .env
+.env.*
 data/
 *.log
 package-lock.json
@@ -9,4 +10,15 @@ backend/tmp/
 backend/data/*.db
 *.xml
 *.gpx
-node_modules/
+
+# Private keys and credentials
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+service-account*.json
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
The .gitignore covers `.env` but would miss `.env.local` or `.env.production`. Added `.env.*` plus entries for private keys (`*.pem`, `*.key`) and credential files. Also removed a duplicate `node_modules/` line and added OS-level ignores.